### PR TITLE
do not resume until module-deps has ended.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = function (files, opts) {
     var tr = through(write, end);
     
     function write (row) {
+        if(hardPause) throw new Error('this should never happen')
         var tr = this;
         if (!opts.always
             && !/\bprocess\b/.test(row.source)


### PR DESCRIPTION
If the dest resumed, through passed that upstream, which sent data through the stream, while still reading from mdep.

this is only a quick hack, so I've left in a fast failing error.

mixing a stream into the current stream like you where doing here was not an intended usecase of through. To do this properly, you need a incoming buffer.

I am happy to help with this, but am super busy right now!
