### PR TITLE
Speed fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,15 @@
         "insert-module-globals": "bin/cmd.js"
     },
     "dependencies": {
-        "browser-resolve": "~0.0.2",
         "commondir": "~0.0.1",
-        "module-deps": "~0.2.0",
         "process": "~0.5.1",
         "through": "~2.2.0",
         "JSONStream": "~0.4.3"
     },
     "devDependencies": {
         "tap": "~0.4.0",
-        "browser-pack": "~0.2.0"
+        "browser-pack": "~0.2.0",
+        "module-deps": "~0.2.0"
     },
     "scripts": {
         "test": "tap test/*.js"


### PR DESCRIPTION
Until we can have "smart" global scope detection that is as fast as this, I think it is safer to err on the side of speed. The overhead for a false positive is not so massive that it matters.

I have also removed the need to do mdeps on the process module path. There are no dependencies and this removes all the strange resume stuff we added.

On another note. It may be interesting to have the AST shipped along with the source. This goes along with some of our discussions from yesterday about a simple `required(src, path, cb)` and detective that could work on an AST.
