### PR TITLE
Globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ module.exports = function (files, opts) {
     }
 
     if(!deps.process) {
-        console.log('loading Buffer', deps);
         var processModulePath = require.resolve('process/browser.js');
 
         deps.process = {
@@ -49,7 +48,6 @@ module.exports = function (files, opts) {
     }
 
     if(!deps.Buffer) {
-        console.log('loading Buffer', deps);
         var bufferModulePath = path.join(__dirname, 'buffer.js');
 
         deps.Buffer = {


### PR DESCRIPTION
Option to add provide custom global `process` and `Buffer` implementations, currently only via `grunt-browserify`:

``` javascript
browserify: {
  bundle: {
    src: [],
    require: ['mongodb', 'tcp_wrap-chromeify'],
    dest: 'app/scripts/vendor/bundle.js',
    ignore: 'node_modules/browser-resolve/node_modules/buffer-browserify/index.js',
    options: {
      globals: {
        process: 'browser-resolve/builtin/process',
        Buffer: 'buffer-browserify'
      }
    }
  }
}
```

Needs substack/node-browserify#386

Working implementation here:
https://github.com/amiuhle/chrome-mongo-admin
