### PR TITLE
remove hashbang before closeOver

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,9 +83,12 @@ module.exports = function (files, opts) {
             var dir = path.dirname('/' + path.relative(basedir, row.id));
             globals.__dirname = JSON.stringify(dir);
         }
+
+        //remove hashbang if present
+        var src = String(src).replace(/^#![^\n]*\n/, '\n');
         
-        row.source = closeOver(globals, row.source);
-        this.queue(row);
+        row.source = closeOver(globals, src);
+        tr.queue(row);
     }
     
     function end () {


### PR DESCRIPTION
before this patch, browserify broke on files with #! in them.
just copied the regexp from lexical-scope.
