### PR TITLE
Use `token-scope` to fast track some files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var detectScope = require('token-scope');
 var parseScope = require('lexical-scope');
 var commondir = require('commondir');
 var through = require('through');
@@ -76,7 +77,7 @@ module.exports = function (files, opts) {
         
         var scope = opts.always
             ? { globals: { implicit: varNames } }
-            : parseScope(row.source)
+            : (hasScope(row.source, varNames) ? parseScope(row.source) : { globals: { implicit: [] } })
         ;
         
         var globals = {};
@@ -123,4 +124,12 @@ function closeOver (globals, src) {
     return '(function(' + keys + '){' + src + '\n})('
         + keys.map(function (key) { return globals[key] }).join(',') + ')'
     ;
+}
+
+function hasScope(src, identifiers) {
+    var scope = detectScope(src)
+    for (var i = 0; i < scope.length; i++) {
+        if (identifiers.indexOf(scope[i]) != -1) return true;
+    }
+    return false;
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "process": "~0.5.1",
         "through": "~2.2.0",
         "duplexer": "~0.0.3",
-        "JSONStream": "~0.4.3"
+        "JSONStream": "~0.4.3",
+        "token-scope": "~1.0.0"
     },
     "devDependencies": {
         "tap": "~0.4.0",


### PR DESCRIPTION
When files don't even have the relevant identifiers, there is no need to spend time walking the parse tree.  Token-scope can run at as much as 3 times the speed, and most large files will probably have no node.js style deps to find.  Unless there happen to be variables named `process` or `global` or whatever, this lets you skip the more complex parsing stage.
