### PR TITLE
Global var's browser equivalant loaded if defined. Node has higher chance to run

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports.vars = _vars
 function closeOver (globals, src) {
     var keys = Object.keys(globals);
     if (keys.length === 0) return src;
-    return 'var ' + keys.map(function (key) {
-        return key + '=' + globals[key];
-    }).join(',') + ';' + src;
+    return keys.map(function (key) {
+        return "if('undefined'!==typeof " + globals[key] + '&&' + globals[key] + ")" + key + "=" + globals[key];
+    }).join(';') + ';' + src;
 }


### PR DESCRIPTION
Changed 

```
var global = globalResolution
```

to

```
if('undefined'!==typeof globalResolution&&globalResolution)global=globalResolution;
```

this is to give the compiled code a higher chance to run in node.js environment without 

`globalResolution is not defined`

errors
