### PR TITLE
update native-buffer-browserify to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "devDependencies": {
         "tap": "~0.4.0",
         "browser-pack": "~0.10.2",
-        "native-buffer-browserify": "~1.1.0",
+        "native-buffer-browserify": "~1.2.2",
         "module-deps": "~1.0.2",
         "browserify": "~2.32.0"
     },


### PR DESCRIPTION
This version should match the one in node-browserify, or else there will be problems right?
