### PR TITLE
Bundle post-install instead of pre-publish!

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+var browserify = require('browserify');
+var cp = require('child_process');
+var fs = require('fs');
+
+var b = browserify({
+  detectGlobals: false
+});
+b.require('native-buffer-browserify');
+
+b.bundle()
+  .pipe(fs.createWriteStream('buffer.js'))
+  .on('close', function () {
+    fs.appendFileSync('buffer.js', ';module.exports=require("native-buffer-browserify").Buffer;\n');
+  });

--- a/bundle.sh
+++ b/bundle.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-browserify --no-detect-globals -r native-buffer-browserify > buffer.js
-echo ';module.exports=require("native-buffer-browserify").Buffer' >> buffer.js

--- a/package.json
+++ b/package.json
@@ -13,18 +13,18 @@
     "through": "~2.3.4",
     "duplexer": "~0.1.1",
     "JSONStream": "~0.7.1",
-    "defined": "0.0.0"
+    "defined": "0.0.0",
+    "native-buffer-browserify": "~2.0.13",
+    "browserify": "~3.24.1"
   },
   "devDependencies": {
     "tap": "~0.4.0",
     "browser-pack": "~0.10.2",
-    "native-buffer-browserify": "~2.0.0",
-    "module-deps": "~1.0.2",
-    "browserify": "~2.32.0"
+    "module-deps": "~1.0.2"
   },
   "scripts": {
     "test": "tap test/*.js",
-    "prepublish": "./bundle.sh"
+    "postinstall": "./build.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The version is native-buffer-browserify is currently stuck at whatever
it was when you last published to npm.

For example, right now ‘insert-module-globals’ is using
native-buffer-browserify@2.0.0 but ‘browserify’ is using 2.0.13.

I know post-install scripts are usually frowned upon, but getting two
different versions of Buffer (one with bug fixes and one without) is
much worse.
