### PR TITLE
use relative path for process/browser.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ var fs = require('fs');
 var processPath = require.resolve('process/browser.js');
 
 var defaultVars = {
-    process: function () {
-        return 'require(' + JSON.stringify(processPath) + ')';
+    process: function (source) {
+        var relativePath = path.relative(path.dirname(source), processPath);
+        return 'require(' + JSON.stringify(relativePath) + ')';
     },
     global: function () {
         return 'typeof self !== "undefined" ? self : '

--- a/test/relative.js
+++ b/test/relative.js
@@ -1,0 +1,11 @@
+var test = require('tap').test;
+var insert = require('../');
+
+test('use relative path for process', function (t) {
+    t.plan(1);
+
+    var expected = '../node_modules/process/browser.js';
+    var result = insert.vars.process();
+
+    t.ok(result.indexOf(expected) !== -1);
+});


### PR DESCRIPTION
Trying (again) to solve the same minor issue as #31 and #32. 
- No more whitespace removal artifacts in this PR.
- The test here is simplistic. Will try to emulate existing test procedures more if this is too crude or dissimilar to the way the existing tests are done.
