### PR TITLE
Closes quotes for correct syntax highlight

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -106,7 +106,7 @@ var vars = {
     },
     Buffer: function (row, basedir) {
         return {
-            id: "path/to/custom_buffer.js,
+            id: 'path/to/custom_buffer.js',
             source: customProcessContent,
             //suffix is optional
             //it's used to extract the value from the module.


### PR DESCRIPTION
I also updated the line to use single quotes as the rest of the readme.
