### PR TITLE
Add setImmediate

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ var defaultVars = {
     Buffer: function () {
         return 'require("buffer").Buffer';
     },
+    setImmediate: function () {
+        return 'require("timers").setImmediate';
+    },
+    clearImmediate: function () {
+        return 'require("timers").clearImmediate';
+    },
     __filename: function (file, basedir) {
         var file = '/' + path.relative(basedir, file);
         return JSON.stringify(file);

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,7 +1,7 @@
 # insert-module-globals
 
 insert implicit module globals
-(`__filename`, `__dirname`, `process`, `global`, and `Buffer`)
+(`__filename`, `__dirname`, `process`, `global`, `setImmediate`, `clearImmediate` and `Buffer`)
 as a browserify-style transform
 
 [![build status](https://secure.travis-ci.org/substack/insert-module-globals.png)](http://travis-ci.org/substack/insert-module-globals)


### PR DESCRIPTION
`setTimeout`, `setInterval`, `setImmediate` and their `clear` counterparts are globals in Node.
`set/clearImmediate` are not available in all browsers, so I added them here.
