### PR TITLE
Fix some more Windows paths issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: "{build}"
+
+environment:
+  matrix:
+    - nodejs_version: "" # lastest
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+build: off
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test

--- a/index.js
+++ b/index.js
@@ -41,11 +41,21 @@ var defaultVars = {
         return 'require("buffer").Buffer';
     },
     __filename: function (file, basedir) {
-        var filename = '/' + path.relative(basedir, file);
+        var relpath = path.relative(basedir, file);
+        // standardize path separators, use slash in Windows too
+        if ( path.sep === '\\' ) {
+          relpath = relpath.replace(/\\/g, '/');
+        }
+        var filename = '/' + relpath;
         return JSON.stringify(filename);
     },
     __dirname: function (file, basedir) {
-        var dir = path.dirname('/' + path.relative(basedir, file));
+        var relpath = path.relative(basedir, file);
+        // standardize path separators, use slash in Windows too
+        if ( path.sep === '\\' ) {
+          relpath = relpath.replace(/\\/g, '/');
+        }
+        var dir = path.dirname('/' + relpath );
         return JSON.stringify(dir);
     }
 };

--- a/test/global.js
+++ b/test/global.js
@@ -2,6 +2,7 @@ var test = require('tape');
 var vm = require('vm');
 var concat = require('concat-stream');
 
+var path = require('path');
 var insert = require('../');
 var bpack = require('browser-pack');
 var mdeps = require('module-deps');
@@ -40,7 +41,7 @@ test('insert globals', function (t) {
 test('__filename and __dirname', function (t) {
     t.plan(2);
     
-    var file = __dirname + '/global/filename.js';
+    var file = path.join(__dirname, 'global', 'filename.js');
     var deps = mdeps()
     var pack = bpack({ raw: true });
     

--- a/test/sourcemap.js
+++ b/test/sourcemap.js
@@ -3,6 +3,7 @@ var convert = require('convert-source-map');
 var insert = require('../');
 var mdeps = require('module-deps');
 var vm = require('vm');
+var path = require('path');
 
 test('sourcemap', function (t) {
     t.plan(6);
@@ -14,7 +15,7 @@ test('sourcemap', function (t) {
         var src = row.source;
         
         var sm = convert.fromSource(src).toObject();
-        t.deepEqual(sm.sources, [ 'test/sourcemap/main_es6.js' ]);
+        t.deepEqual(sm.sources, [ path.join('test', 'sourcemap', 'main_es6.js')]);
         t.deepEqual(sm.sourcesContent, [ 'console.log(`${__dirname}`, `${__filename}`);\n' ]);
         t.deepEqual(sm.mappings, ';AAAA,OAAO,CAAC,GAAG,MAAI,SAAS,OAAO,UAAU,CAAG,CAAC');
         

--- a/test/unprefix.js
+++ b/test/unprefix.js
@@ -2,6 +2,7 @@ var test = require('tape');
 var vm = require('vm');
 var concat = require('concat-stream');
 
+var path = require('path');
 var insert = require('../');
 var bpack = require('browser-pack');
 var mdeps = require('module-deps');
@@ -9,7 +10,7 @@ var mdeps = require('module-deps');
 test('unprefix - remove shebang and bom', function (t) {
     t.plan(3);
     
-    var file = __dirname + '/unprefix/main.js';
+    var file = path.join(__dirname, 'unprefix', 'main.js');
     var deps = mdeps();
     var pack = bpack({ raw: true });
     


### PR DESCRIPTION
When using `__filename` in Browserify, I was getting mixed path separators, like `/stores\MyStore.js`. 

When searching issues and PRs, I found that similar issue is [fixed earlier](https://github.com/substack/insert-module-globals/blob/master/index.js#L18). So I thought I´d apply same fix to `__filename` and `__dirname` too. But before doing anything, I ran `npm test` and learnt it doesnt pass in Windows. So I had to fix couple of tests too, by using `path.join`, to get it work.

Also, currently, PR includes `appveyor.yml` [equivalent](https://ci.appveyor.com/project/apihlaja/insert-module-globals) of your Travis config. Considering there have been quite many [Windows related issues](https://github.com/substack/insert-module-globals/issues?q=windows) lately, it might be good idea to start using Windows based CI too.
