### PR TITLE
./-prefix relative paths in subdirectories

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ var combineSourceMap = require('combine-source-map');
 
 function getRelativeRequirePath(fullPath, fromPath) {
   var relpath = path.relative(path.dirname(fromPath), fullPath);
-  // If fullPath is in the same directory as fromPath, relpath will
-  // result in something like "index.js". require() needs "./" prepended
-  // to these paths.
-  if (path.dirname(relpath) === '.') {
+  // If fullPath is in the same directory or a subdirectory of fromPath,
+  // relpath will result in something like "index.js", "src/abc.js".
+  // require() needs "./" prepended to these paths.
+  if (!/^\./.test(relpath)) {
     relpath = "./" + relpath;
   }
   // On Windows: Convert path separators to what require() expects

--- a/test/subdir.js
+++ b/test/subdir.js
@@ -1,0 +1,37 @@
+var test = require('tape');
+var mdeps = require('module-deps');
+var bpack = require('browser-pack');
+var insert = require('../');
+var concat = require('concat-stream');
+var path = require('path');
+var fs = require('fs');
+var vm = require('vm');
+
+test('subdir', function (t) {
+    t.plan(1);
+    var deps = mdeps()
+    var pack = bpack({ raw: true, hasExports: true });
+    deps.pipe(pack).pipe(concat(function (src) {
+        var c = {
+            console: { log: log }
+        };
+        vm.runInNewContext(src, c);
+        function log (value) {
+            t.equal(value, false);
+        }
+    }));
+    deps.write({ transform: inserter, global: true });
+    deps.end({
+        id: 'main',
+        // Fake the file path so that the relative path to is-buffer becomes
+        // "node_modules/is-buffer/index.js"
+        file: path.join(__dirname, '../subdir_test.js'),
+        source: fs.readFileSync(__dirname + '/subdir/main.js')
+    });
+});
+
+function inserter (file) {
+    return insert(file, {
+        basedir: path.join(__dirname, '..')
+    });
+}

--- a/test/subdir/main.js
+++ b/test/subdir/main.js
@@ -1,0 +1,1 @@
+console.log(Buffer.isBuffer("test"))


### PR DESCRIPTION
Having a file in the same directory isn't the only situation in which
the `require()` path needs to be prefixed with ./; it also happens when
the target file is in a subdirectory. For example, inside a node_modules
directory adjacent to the source file.

Fixes browserify/browserify#1531