### PR TITLE
Update concat-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "JSONStream": "^1.0.3",
     "combine-source-map": "~0.7.1",
-    "concat-stream": "~1.5.1",
+    "concat-stream": "^1.6.1",
     "is-buffer": "^1.1.0",
     "lexical-scope": "^1.2.0",
     "process": "~0.11.0",


### PR DESCRIPTION
This allows npm to dedupe concat-stream versions used by module-deps and
insert-module-globals.