### PR TITLE
Update combine-source-map, fixes #68

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
-    "combine-source-map": "~0.7.1",
+    "combine-source-map": "^0.8.0",
     "concat-stream": "^1.6.1",
     "is-buffer": "^1.1.0",
     "lexical-scope": "^1.2.0",

--- a/test/sourcemap.js
+++ b/test/sourcemap.js
@@ -15,7 +15,7 @@ test('sourcemap', function (t) {
         var src = row.source;
         
         var sm = convert.fromSource(src).toObject();
-        t.deepEqual(sm.sources, [ path.join('test', 'sourcemap', 'main_es6.js')]);
+        t.deepEqual(sm.sources, [ 'test/sourcemap/main_es6.js' ]);
         t.deepEqual(sm.sourcesContent, [ 'console.log(`${__dirname}`, `${__filename}`);\n' ]);
         t.deepEqual(sm.mappings, ';AAAA,OAAO,CAAC,GAAG,MAAI,SAAS,OAAO,UAAU,CAAG,CAAC');
         


### PR DESCRIPTION
This version makes sure that /-delimited paths are used rather than \\-delimited ones:

https://github.com/thlorenz/combine-source-map/commit/8d9d385d9111af24a18d1c6111642c63696e3c0a