### PR TITLE
Fix relative path resolution between Windows partitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var through = require('through2');
 var merge = require('xtend');
 
 var path = require('path');
+var isAbsolute = path.isAbsolute || require('path-is-absolute');
 var processPath = require.resolve('process/browser.js');
 var isbufferPath = require.resolve('is-buffer')
 var combineSourceMap = require('combine-source-map');
@@ -12,7 +13,7 @@ function getRelativeRequirePath(fullPath, fromPath) {
   // If fullPath is in the same directory or a subdirectory of fromPath,
   // relpath will result in something like "index.js", "src/abc.js".
   // require() needs "./" prepended to these paths.
-  if (!/^\./.test(relpath) && !path.isAbsolute(relpath)) {
+  if (!/^\./.test(relpath) && !isAbsolute(relpath)) {
     relpath = "./" + relpath;
   }
   // On Windows: Convert path separators to what require() expects

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function getRelativeRequirePath(fullPath, fromPath) {
   // If fullPath is in the same directory or a subdirectory of fromPath,
   // relpath will result in something like "index.js", "src/abc.js".
   // require() needs "./" prepended to these paths.
-  if (!/^\./.test(relpath)) {
+  if (!/^\./.test(relpath) && !path.isAbsolute(relpath)) {
     relpath = "./" + relpath;
   }
   // On Windows: Convert path separators to what require() expects

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "concat-stream": "^1.6.1",
     "is-buffer": "^1.1.0",
     "lexical-scope": "^1.2.0",
+    "path-is-absolute": "^1.0.1",
     "process": "~0.11.0",
     "through2": "^2.0.0",
     "xtend": "^4.0.0"

--- a/test/roots.js
+++ b/test/roots.js
@@ -1,0 +1,35 @@
+var test = require('tape');
+var mdeps = require('module-deps');
+var bpack = require('browser-pack');
+var insert = require('../');
+var concat = require('concat-stream');
+var path = require('path');
+var fs = require('fs');
+var vm = require('vm');
+
+test('windows partitions', { skip: process.platform !== 'win32' }, function (t) {
+    t.plan(1);
+    var deps = mdeps()
+    var pack = bpack({ raw: true, hasExports: true });
+    deps.pipe(pack).pipe(concat(function (src) {
+        var c = {
+            console: { log: log }
+        };
+        vm.runInNewContext(src, c);
+        function log (value) {
+            t.equal(typeof value, 'function');
+        }
+    }));
+    deps.write({ transform: inserter, global: true });
+    deps.end({
+        id: 'main',
+        file: 'D:\\test.js',
+        source: fs.readFileSync(__dirname + '/roots/main.js')
+    });
+});
+
+function inserter (file) {
+    return insert(file, {
+        basedir: path.join(__dirname, '..')
+    });
+}

--- a/test/roots/main.js
+++ b/test/roots/main.js
@@ -1,0 +1,1 @@
+console.log(Buffer.isBuffer)


### PR DESCRIPTION
When a source file on D:\\ requires something from a global browserify installation on C:\\, `path.relative` returns the `C:\whatever` path. The regex here was matching `C:\` as a relative path and adding ./ in front, but it should be treated as an absolute path instead. This patch adds a check so absolute paths are untouched.

Fixes #74 
Fixes browserify/browserify#1825