### PR TITLE
use undeclared-identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ module.exports = function (file, opts) {
         try {
             var undeclared = opts.always
                 ? { identifiers: varNames, properties: [] }
-                : undeclaredIdentifiers(source)
+                : undeclaredIdentifiers(source, { wildcard: true })
             ;
         }
         catch (err) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var undeclaredIdentifiers = require('undeclared-identifiers');
 var through = require('through2');
 var merge = require('xtend');
+var parse = require('acorn-node').parse;
 
 var path = require('path');
 var isAbsolute = path.isAbsolute || require('path-is-absolute');
@@ -106,7 +107,7 @@ module.exports = function (file, opts) {
         try {
             var undeclared = opts.always
                 ? { identifiers: varNames, properties: [] }
-                : undeclaredIdentifiers(source, { wildcard: true })
+                : undeclaredIdentifiers(parse(source), { wildcard: true })
             ;
         }
         catch (err) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "path-is-absolute": "^1.0.1",
     "process": "~0.11.0",
     "through2": "^2.0.0",
-    "undeclared-identifiers": "^1.0.0",
+    "undeclared-identifiers": "^1.1.2",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
+    "acorn-node": "^1.5.2",
     "combine-source-map": "^0.8.0",
     "concat-stream": "^1.6.1",
     "is-buffer": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
     "combine-source-map": "^0.8.0",
     "concat-stream": "^1.6.1",
     "is-buffer": "^1.1.0",
-    "lexical-scope": "^1.2.0",
     "path-is-absolute": "^1.0.1",
     "process": "~0.11.0",
     "through2": "^2.0.0",
+    "undeclared-identifiers": "^1.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
     "browser-pack": "^6.0.0",
-    "buffer": "^3.0.0",
+    "buffer": "^4.9.1",
     "convert-source-map": "~1.1.0",
     "module-deps": "^4.0.2",
     "nanobench": "^2.1.1",

--- a/test/isbuffer.js
+++ b/test/isbuffer.js
@@ -25,7 +25,7 @@ test('isbuffer', function (t) {
     deps.end({ id: 'main', file: __dirname + '/isbuffer/main.js' });
 });
 
-test('isbuffer (and buffer)', function (t) {
+test('isbuffer (and Buffer.from)', function (t) {
     t.plan(5);
     var deps = mdeps()
     var pack = bpack({ raw: true, hasExports: true });
@@ -40,6 +40,23 @@ test('isbuffer (and buffer)', function (t) {
     }));
     deps.write({ transform: inserter, global: true });
     deps.end({ id: 'main', file: __dirname + '/isbuffer/both.js' });
+});
+
+test('isbuffer (and new Buffer)', function (t) {
+    t.plan(5);
+    var deps = mdeps()
+    var pack = bpack({ raw: true, hasExports: true });
+    deps.pipe(pack).pipe(concat(function (src) {
+        var c = { global: {} };
+        vm.runInNewContext(src, c);
+        t.equal(c.require('main')(c.require('main').a()), true, 'is a buffer');
+        t.equal(c.require('main')('wow'), false, 'is not a buffer');
+        t.equal(isBuffer(c.require('main').a()), true, 'is a buffer');
+        t.ok(/require\("buffer"\)/.test(src), 'buffer required in source')
+        t.equal(c.require('main').a().toString('hex'), 'abcd', 'is a buffer');
+    }));
+    deps.write({ transform: inserter, global: true });
+    deps.end({ id: 'main', file: __dirname + '/isbuffer/new.js' });
 });
 
 function inserter (file) {

--- a/test/isbuffer.js
+++ b/test/isbuffer.js
@@ -53,7 +53,7 @@ test('isbuffer (and new Buffer)', function (t) {
         t.equal(c.require('main')('wow'), false, 'is not a buffer');
         t.equal(isBuffer(c.require('main').a()), true, 'is a buffer');
         t.ok(/require\("buffer"\)/.test(src), 'buffer required in source')
-        t.equal(c.require('main').a().toString('hex'), 'abcd', 'is a buffer');
+        t.equal(c.require('main').a().toString('utf8'), 'abcd', 'is a buffer');
     }));
     deps.write({ transform: inserter, global: true });
     deps.end({ id: 'main', file: __dirname + '/isbuffer/new.js' });

--- a/test/isbuffer.js
+++ b/test/isbuffer.js
@@ -4,6 +4,9 @@ var bpack = require('browser-pack');
 var insert = require('../');
 var concat = require('concat-stream');
 var vm = require('vm');
+// use is-buffer instead of builtin Buffer.isBuffer. The builtin
+// does `instanceof` which does not work on the browserified version
+var isBuffer = require('is-buffer');
 
 test('isbuffer', function (t) {
     t.plan(5);
@@ -20,6 +23,23 @@ test('isbuffer', function (t) {
     }));
     deps.write({ transform: inserter, global: true });
     deps.end({ id: 'main', file: __dirname + '/isbuffer/main.js' });
+});
+
+test('isbuffer (and buffer)', function (t) {
+    t.plan(5);
+    var deps = mdeps()
+    var pack = bpack({ raw: true, hasExports: true });
+    deps.pipe(pack).pipe(concat(function (src) {
+        var c = { global: {} };
+        vm.runInNewContext(src, c);
+        t.equal(c.require('main')(c.require('main').a()), true, 'is a buffer');
+        t.equal(c.require('main')('wow'), false, 'is not a buffer');
+        t.equal(isBuffer(c.require('main').a()), true, 'is a buffer');
+        t.ok(/require\("buffer"\)/.test(src), 'buffer required in source')
+        t.equal(c.require('main').a().toString('hex'), 'abcd', 'is a buffer');
+    }));
+    deps.write({ transform: inserter, global: true });
+    deps.end({ id: 'main', file: __dirname + '/isbuffer/both.js' });
 });
 
 function inserter (file) {

--- a/test/isbuffer/both.js
+++ b/test/isbuffer/both.js
@@ -1,0 +1,6 @@
+module.exports = function (buf) {
+    return Buffer.isBuffer(buf);
+};
+module.exports.a = function () {
+    return Buffer.from('abcd', 'hex');
+};

--- a/test/isbuffer/new.js
+++ b/test/isbuffer/new.js
@@ -1,0 +1,6 @@
+module.exports = function (buf) {
+    return Buffer.isBuffer(buf);
+};
+module.exports.a = function () {
+    return new Buffer('abcd');
+};


### PR DESCRIPTION
undeclared-identifiers collects references to undeclared identifiers and their properties. It does much less work than lexical-scope so it is quite a bit faster.

before:

    # jquery
    ok ~432 ms (0 s + 432086435 ns)

after:

    # jquery
    ok ~223 ms (0 s + 223387040 ns)