### PR TITLE
Update `acorn-node` to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
-    "acorn-node": "^1.5.2",
+    "acorn-node": "^2.0.1",
     "combine-source-map": "^0.8.0",
     "concat-stream": "^1.6.1",
     "is-buffer": "^1.1.0",


### PR DESCRIPTION
This is a breaking change because the handling of dynamic imports has changed in `acord-node@v2`. See here for more details: https://github.com/browserify/acorn-node/pull/12